### PR TITLE
Check for libraries other than jQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ gem 'jquery-rails'
 gem 'cdnjs-rails'
 ```
 
-- In the supplied demo app, we are including 2 libraries `jquery` and `jquery-ui` where `cdnjs` is the name of the partial path on [cdnjs.com](http://cdnjs.com/) and `localpath` matches the folder path in your local application i.e. vendor directory. Add this to your `config/application.rb` file so that it is loaded in all environments:
+- In the supplied demo app, we are including 2 libraries `jquery` and `jquery-ui` where `cdnjs` is the name of the partial path on [cdnjs.com](http://cdnjs.com/) and `localpath` matches the folder path in your local application i.e. vendor directory, and :windowvar matches a variable that is added to the global scope by the library. Add this to your `config/application.rb` file so that it is loaded in all environments:
 
 ```ruby
 # Specify CDNJS Libraries to include in the header with fallback using an array of hashes
 config.cdnjs = [
-  {:cdnjs => 'jquery/2.0.2/jquery.min.js', :localpath => 'jquery.js'},
-  {:cdnjs => 'jqueryui/1.10.3/jquery-ui.min.js', :localpath => 'jquery-ui.min.js'}
+  {:cdnjs => 'jquery/2.0.2/jquery.min.js', :localpath => 'jquery.js', :windowvar => 'jQuery'},
+  {:cdnjs => 'jqueryui/1.10.3/jquery-ui.min.js', :localpath => 'jquery-ui.min.js', :windowvar => 'jQuery.ui'}
 ]
 ```
 

--- a/cdnjs-rails.gemspec
+++ b/cdnjs-rails.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.name              = "cdnjs-rails"
   s.licenses          = "GPL"
-  s.version           = '1.0.0'
+  s.version           = '1.0.1'
 
 end
 

--- a/lib/cdnjs-rails/view_helpers.rb
+++ b/lib/cdnjs-rails/view_helpers.rb
@@ -3,7 +3,7 @@ module CDNJS
     def cdnjs_include_tag(cdn_vars=nil)
       cdn_vars       ||= Rails.application.config.cdnjs
       js_string_output = Array.new
-      
+
       cdn_vars.each do |js_file_config|
         window_var = js_file_config.fetch(:windowvar)
         split_vars = window_var.split(".")
@@ -18,6 +18,8 @@ module CDNJS
 
           window_path << var_check.join(".") + " && "
         end
+
+        window_path.chomp!(" && ")
 
         js_string_output << javascript_include_tag("//cdnjs.cloudflare.com/ajax/libs/#{js_file_config.fetch(:cdnjs)}")
         js_string_output << javascript_tag("(#{window_path}) || document.write(unescape('#{asset_path(js_file_config.fetch(:localpath)).gsub('<','%3C')}'))")

--- a/lib/cdnjs-rails/view_helpers.rb
+++ b/lib/cdnjs-rails/view_helpers.rb
@@ -22,7 +22,7 @@ module CDNJS
         window_path.chomp!(" && ")
 
         js_string_output << javascript_include_tag("//cdnjs.cloudflare.com/ajax/libs/#{js_file_config.fetch(:cdnjs)}")
-        js_string_output << javascript_tag("(#{window_path}) || document.write(unescape('#{asset_path(js_file_config.fetch(:localpath)).gsub('<','%3C')}'))")
+        js_string_output << javascript_tag("(#{window_path}) || document.write(unescape(\"%3Cscript src='#{asset_path(js_file_config.fetch(:localpath)).gsub('<','%3C')}' type='text/javascript'%3E%3C/script%3E\"))")
       end
 
       js_string_output.join("\n").html_safe

--- a/lib/cdnjs-rails/view_helpers.rb
+++ b/lib/cdnjs-rails/view_helpers.rb
@@ -3,15 +3,28 @@ module CDNJS
     def cdnjs_include_tag(cdn_vars=nil)
       cdn_vars       ||= Rails.application.config.cdnjs
       js_string_output = Array.new
-
+      
       cdn_vars.each do |js_file_config|
+        window_var = js_file_config.fetch(:windowvar)
+        split_vars = window_var.split(".")
+        window_path = ""
+
+        split_vars.each_with_index do |val, index|
+          var_check = ["window"]
+
+          0.upto(index) do |i|
+            var_check.push split_vars[i]
+          end
+
+          window_path << var_check.join(".") + " && "
+        end
+
         js_string_output << javascript_include_tag("//cdnjs.cloudflare.com/ajax/libs/#{js_file_config.fetch(:cdnjs)}")
-        js_string_output << javascript_tag("window.jQuery || document.write(unescape('#{asset_path(js_file_config.fetch(:localpath)).gsub('<','%3C')}'))")
+        js_string_output << javascript_tag("(#{window_path}) || document.write(unescape('#{asset_path(js_file_config.fetch(:localpath)).gsub('<','%3C')}'))")
       end
 
       js_string_output.join("\n").html_safe
     end
   end
 end
-
 


### PR DESCRIPTION
In the current version you only check for window.jQuery no matter what library you are loading from cdnjs. This lets you specify a window variable to check (e.g. `:windowvar => "angular"`) for apps that don't use jQuery